### PR TITLE
feat: expose config for block HTTP response

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ LLM Bot user agents are retrieved from [ai-robots-txt](https://github.com/ai-rob
 
 - `PASS`: Do nothing (no-op)
 - `LOG`: write a log message about the visitor, the default behavior
-- `BLOCK`: reject the request with a 403 error
+- `BLOCK`: reject the request with a static response (a 403 error by default)
 - `PROXY`: proxy the request to a "tarpit" or other service to handle bot traffic, such as [Nepenthes](https://zadzmo.org/code/nepenthes/), [iocaine](https://iocaine.madhouse-project.org), etc
 
 ## Table Of Contents
@@ -54,9 +54,11 @@ The follow parameters are exposed to configure this plugin
 |------|---------------|-------------|
 |enabled|`true`|Whether or not the plugin should be enabled|
 |cacheUpdateInterval|`24h`|How frequently the robots list should be updated|
-|botAction|`LOG`|How the bot should be wrangled. Available: `PASS` (do nothing), `LOG` (log bot info), `BLOCK` (log and return 403), `PROXY` (log and proxy to `botProxyUrl`)|
+|botAction|`LOG`|How the bot should be wrangled. Available: `PASS` (do nothing), `LOG` (log bot info), `BLOCK` (log and return static error response), `PROXY` (log and proxy to `botProxyUrl`)|
 |botProxyUrl|`""`|The URL to pass a bot's request to, if `PROXY` is the set `botAction`|
-|logLevel|`INFO`|THe log level for the plugin|
+|botBlockHttpCode|`403`|The HTTP response code that should be returned when a `BLOCK` action is taken|
+|botBlockHttpContent|`"Your user agent is associated with a large language model (LLM) and is blocked from accessing this resource"`|The value of the 'message' key in the JSON response when a `BLOCK` action is taken. If an empty string, the response body has no content.|
+|logLevel|`INFO`|The log level for the plugin|
 |robotsTxtFilePath|`robots.txt`| The file path to the robots.txt template file. You can customize the provided file as desired|
 |robotsSourceUrl|`https://raw.githubusercontent.com/ai-robots-txt/ai.robots.txt/refs/heads/main/robots.json`|A URL to a JSON formatted robot user agent index. You can provide your own, but ensure it has the same JSON keys!|
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -30,7 +30,8 @@ services:
 
       - "traefik.http.routers.router-bar.middlewares=bot-wrangler"
       - "traefik.http.services.service-bar.loadbalancer.server.port=80"
-      - "traefik.http.middlewares.bot-wrangler.plugin.wrangler.botaction=PROXY"
+      - "traefik.http.middlewares.bot-wrangler.plugin.wrangler.botaction=BLOCK"
+      - "traefik.http.middlewares.bot-wrangler.plugin.wrangler.botBlockHttpCode=403"
       - "traefik.http.middlewares.bot-wrangler.plugin.wrangler.loglevel=DEBUG"
       - "traefik.http.middlewares.bot-wrangler.plugin.wrangler.cacheUpdateInterval=1m"
       - "traefik.http.middlewares.bot-wrangler.plugin.wrangler.botProxyUrl=http://backend:80"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -59,6 +59,16 @@ func TestConfigBadBotAction(t *testing.T) {
 	}
 }
 
+// TestConfigBadBotBlockHTTPCode overrides a default config with an invalid BotBlockHTTPCode and checks that an error is raised by ValidateConfig().
+func TestConfigBadBotBlockHTTPCode(t *testing.T) {
+	c := New()
+	c.BotBlockHTTPCode = 999
+	err := c.ValidateConfig()
+	if err == nil {
+		t.Error("ValidateConfig didn't fail an invalid BotBlockHTTPCode.")
+	}
+}
+
 // TestConfigBadBotProxyURL overrides a default config with an invalid BotProxyURL and checks that an error is raised by ValidateConfig().
 func TestConfigBadBotProxyURL(t *testing.T) {
 	c := New()

--- a/wrangler_test.go
+++ b/wrangler_test.go
@@ -303,7 +303,7 @@ func TestWranglerBlockAction(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := res.StatusCode == http.StatusForbidden && res.Header.Get("Content-Type") == "application/json" && blockedBody.Error == "Forbidden" &&
-		blockedBody.Message == "Your user agent is associated with a large language model (LLM) and is blocked from accessing this resource due to scraping activities."
+		blockedBody.Message == "Your user agent is associated with a large language model (LLM) and is blocked from accessing this resource"
 	if !want {
 		t.Errorf("request passed to plugin with BotAction '%s' from User-Agent '%s' did not match expected response", action, BotUserAgent)
 	}
@@ -397,7 +397,7 @@ func TestWranglerProxyActionNoInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := res.StatusCode == http.StatusForbidden && res.Header.Get("Content-Type") == "application/json" && blockedBody.Error == "Forbidden" && blockedBody.Message == "Your user agent is associated with a large language model (LLM) and is blocked from accessing this resource due to scraping activities."
+	want := res.StatusCode == http.StatusForbidden && res.Header.Get("Content-Type") == "application/json" && blockedBody.Error == "Forbidden" && blockedBody.Message == "Your user agent is associated with a large language model (LLM) and is blocked from accessing this resource"
 	if !want {
 		t.Errorf("request from bot that should've been proxied and failed did not return a blocked fallback response")
 	}


### PR DESCRIPTION
This PR allows configuration of both the HTTP error code, and message in the JSON message returned when a `BLOCK` action is performed.

If the provided JSON message is an empty string, the `BLOCK` response will skip writing anything to the response body, resulting in a bare HTTP error response.

Closes #19 