### PR TITLE
feat: config option for robots.txt to disallow all user-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ The follow parameters are exposed to configure this plugin
 |botBlockHttpCode|`403`|The HTTP response code that should be returned when a `BLOCK` action is taken|
 |botBlockHttpContent|`"Your user agent is associated with a large language model (LLM) and is blocked from accessing this resource"`|The value of the 'message' key in the JSON response when a `BLOCK` action is taken. If an empty string, the response body has no content.|
 |logLevel|`INFO`|The log level for the plugin|
-|robotsTxtFilePath|`""`| The file path to a custom robots.txt Golang template file. See `robots.txt` in the repo for an example|
+|robotsTxtFilePath|`""`| The file path to a custom robots.txt Golang template file. If one is not provided, a default will be generated based on the user agents from your `robotsSourceUrl`. See the `robots.txt` in the repo|
+|robotsTxtDisallowAll|`false`|A config option to generate a robots.txt file that will disallow all user-agents. This does not change the blocking behavior of the middleware.|
 |robotsSourceUrl|`https://raw.githubusercontent.com/ai-robots-txt/ai.robots.txt/refs/heads/main/robots.json`|A URL to a JSON formatted robot user agent index. You can provide your own, but ensure it has the same JSON keys!|
 
 ### "Tarpits" to Send Bots to

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,14 @@ Disallow: /
 `
 )
 
+// robots.txt template that will disallow all user-agents.
+const (
+	RobotsTxtDisallowAll = `
+User-agent: *
+Disallow: /
+`
+)
+
 // Config the plugin configuration.
 type Config struct {
 	Enabled              string `json:"enabled,omitempty"`
@@ -43,6 +51,7 @@ type Config struct {
 	CacheUpdateInterval  string `json:"cacheUpdateInterval,omitempty"`
 	LogLevel             string `json:"logLevel,omitempty"`
 	RobotsTXTFilePath    string `json:"robotsTxtFilePath,omitempty"`
+	RobotsTXTDisallowAll bool   `json:"robotsTxtDisallowAll,omitempty"`
 	RobotsSourceURL      string `json:"robotsSourceUrl,omitempty"`
 }
 
@@ -57,6 +66,7 @@ func New() *Config {
 		CacheUpdateInterval:  "24h",
 		LogLevel:             "INFO",
 		RobotsTXTFilePath:    "",
+		RobotsTXTDisallowAll: false,
 		RobotsSourceURL:      "https://raw.githubusercontent.com/ai-robots-txt/ai.robots.txt/refs/heads/main/robots.json",
 	}
 }

--- a/wrangler.go
+++ b/wrangler.go
@@ -46,11 +46,16 @@ func New(_ context.Context, next http.Handler, c *config.Config, name string) (h
 		log.Error("New: unable to load configuration properly. " + err.Error())
 		return nil, err
 	}
+
 	t := template.New("tmp")
 	var loadedT *template.Template
-	if c.RobotsTXTFilePath == "" {
+	switch {
+	case c.RobotsTXTDisallowAll:
+		log.Info("New: robotsTxtDisallowAll specified, robots.txt will disallow all user-agents")
+		loadedT, err = t.Parse(config.RobotsTxtDisallowAll)
+	case c.RobotsTXTFilePath == "":
 		loadedT, err = t.Parse(config.RobotsTxtDefault)
-	} else {
+	default:
 		log.Info("New: Custom robots.txt template file '" + c.RobotsTXTFilePath + "' specified, parsing..")
 		loadedT, err = t.ParseFiles(c.RobotsTXTFilePath)
 	}
@@ -58,6 +63,7 @@ func New(_ context.Context, next http.Handler, c *config.Config, name string) (h
 		log.Error("New: Unable to load robots.txt template. " + err.Error())
 		return nil, err
 	}
+
 	uAMan, err := botmanager.New(c.RobotsSourceURL, c.CacheUpdateInterval, log)
 	if err != nil {
 		log.Error("New: Unable to initialize bot user agent list manager. " + err.Error())


### PR DESCRIPTION
Per feedback, it would be useful to have a config option that generates a robots.txt that disallows all user agents. This will not change the behavior of the actual blocking actions of the Middleware.

This is configurable with the new `robotsTxtDisallowAll` config option

Closes #23