### PR TITLE
feat: set X-Robots-Tag header to noarchive for bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The follow parameters are exposed to configure this plugin
 |robotsTxtDisallowAll|`false`|A config option to generate a robots.txt file that will disallow all user-agents. This does not change the blocking behavior of the middleware.|
 |robotsSourceUrl|`https://cdn.jsdelivr.net/gh/ai-robots-txt/ai.robots.txt/robots.json`|A comma separated list of URLs to retrieve a bot list. You can provide your own, but read the notes below!|
 |robotsSourceRetryInterval|`5m`|If retrieving data from a source fails, how frequently to retry|
+|setNoArchiveHeader|`true`|Set the `X-Robots-Tag` header to `noarchive` in responses to detected bot traffic. Used by [Bing](https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240) and [Amazon](developer.amazon.com/en/amazonbot), possibly others.|
 |useFastMatch|`true`|When `true`, use an Aho-Corasick automaton for speedily matching uncached User-Agents against Bot Names. Consumes more memory. `false` relies on a slower, simple substring match.|
 
 ### Providing Custom Robots Sources

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: "traefik:v3.3"
+    image: "traefik:v3"
     container_name: "traefik"
     restart: unless-stopped
     command:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	CacheSize                 int    `json:"cacheSize,omitempty"`
 	CacheUpdateInterval       string `json:"cacheUpdateInterval,omitempty"`
 	LogLevel                  string `json:"logLevel,omitempty"`
+	SetNoArchiveHeader        bool   `json:"setNoArchiveHeader,omitempty"`
 	RobotsTXTFilePath         string `json:"robotsTxtFilePath,omitempty"`
 	RobotsTXTDisallowAll      bool   `json:"robotsTxtDisallowAll,omitempty"`
 	RobotsSourceURL           string `json:"robotsSourceUrl,omitempty"`
@@ -71,6 +72,7 @@ func New() *Config {
 		CacheSize:                 defaultMaxCacheSize,
 		CacheUpdateInterval:       "24h",
 		LogLevel:                  "INFO",
+		SetNoArchiveHeader:        true,
 		RobotsTXTFilePath:         "",
 		RobotsTXTDisallowAll:      false,
 		RobotsSourceURL:           "https://cdn.jsdelivr.net/gh/ai-robots-txt/ai.robots.txt@v1.42/robots.json",

--- a/wrangler.go
+++ b/wrangler.go
@@ -27,6 +27,7 @@ type Wrangler struct {
 	botUAManager         *botmanager.BotUAManager
 	log                  *logger.Log
 	proxy                *proxy.BotProxy
+	setNoArchiveHeader   bool
 }
 
 // CreateConfig creates the default plugin configuration.
@@ -66,6 +67,7 @@ func New(_ context.Context, next http.Handler, c *config.Config, name string) (h
 		botBlockHTTPCode:     c.BotBlockHTTPCode,
 		botBlockHTTPResponse: c.BotBlockHTTPResponse,
 		log:                  log,
+		setNoArchiveHeader:   c.SetNoArchiveHeader,
 		proxy:                bP,
 	}, nil
 }
@@ -113,6 +115,12 @@ func (w *Wrangler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			uAMetadata.Respect, "function", uAMetadata.Function, "description", uAMetadata.Description,
 		)
 	}
+
+	// if specified, set the X-Robots-Tag header
+	if w.setNoArchiveHeader {
+		rw.Header().Add("X-Robots-Tag", "noarchive")
+	}
+
 	// handle outcome of the request for the bot.
 	w.handleOutcome(rw, req)
 }


### PR DESCRIPTION
This PR adds functionality to send a `X-Robots-Tag` header in any response to a bot (actual content, block, etc). This opts out of AI training for bing, amazon, and potentially other bots, while still allowing scraping.

This is not sent for `/robots.txt`, or any traffic not matching a bot from the provided source(s).

Closes #28 