### PR TITLE
fix: RobotsTxtFilePath only works for files named tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The follow parameters are exposed to configure this plugin
 |cacheUpdateInterval|`24h`|How frequently sources should be refreshed for new bots. Also flushes the User-Agent cache.|
 |cacheSize|`500`|The maximum size of the cache of User-Agent to Bot Name mappings. Rolls over when full.|
 |logLevel|`INFO`|The log level for the plugin|
-|robotsTxtFilePath|`""`| The file path to a custom robots.txt Golang template file. If one is not provided, a default will be generated based on the user agents from your `robotsSourceUrl`. See the `robots.txt` in the repo|
+|robotsTxtFilePath|`""`| The file path to a custom robots.txt Golang template file. This **must** end in `/robots.txt`. If omitted, a default will be generated based on the user agents from your `robotsSourceUrl`. [See example here](/robots.txt).|
 |robotsTxtDisallowAll|`false`|A config option to generate a robots.txt file that will disallow all user-agents. This does not change the blocking behavior of the middleware.|
 |robotsSourceUrl|`https://cdn.jsdelivr.net/gh/ai-robots-txt/ai.robots.txt/robots.json`|A comma separated list of URLs to retrieve a bot list. You can provide your own, but read the notes below!|
 |robotsSourceRetryInterval|`5m`|If retrieving data from a source fails, how frequently to retry|

--- a/pkg/botmanager/botmanager.go
+++ b/pkg/botmanager/botmanager.go
@@ -79,7 +79,7 @@ type BotUAManager struct {
 }
 
 func loadTemplate(disallowAll bool, templatePath string, log *logger.Log) (*template.Template, error) {
-	t := template.New("tmp")
+	t := template.New("robots.txt")
 	var loadedT *template.Template
 	var err error
 	switch {

--- a/pkg/botmanager/botmanager_test.go
+++ b/pkg/botmanager/botmanager_test.go
@@ -328,7 +328,7 @@ func TestRenderRobotsTxtCustomTemplate(t *testing.T) {
 		t.Error("Initializing the botmanager with a custom RobotsTXTFilePath failed: " + err.Error())
 	}
 
-	w := &badResponseWriter{}
+	w := &bytes.Buffer{}
 	err = b.RenderRobotsTxt(w, true)
 
 	if err != nil {

--- a/pkg/botmanager/botmanager_test.go
+++ b/pkg/botmanager/botmanager_test.go
@@ -317,6 +317,25 @@ func TestInitBadRobotsTemplate(t *testing.T) {
 	}
 }
 
+// TestRenderRobotsTxtCustomTemplate tests that when a custom robots.txt template is provided, the plugin properly renders a robots.txt to clients
+func TestRenderRobotsTxtCustomTemplate(t *testing.T) {
+	log := logger.NewFromWriter("DEBUG", &testLogOut)
+	c := config.New()
+	// use example template in root
+	c.RobotsTXTFilePath = "../../robots.txt"
+	b, err := New(c.RobotsSourceURL, c.CacheUpdateInterval, log, c.CacheSize, c.UseFastMatch, c.RobotsTXTDisallowAll, c.RobotsTXTFilePath, c.RobotsSourceRetryInterval)
+	if err != nil {
+		t.Error("Initializing the botmanager with a custom RobotsTXTFilePath failed: " + err.Error())
+	}
+
+	w := &badResponseWriter{}
+	err = b.RenderRobotsTxt(w, true)
+
+	if err != nil {
+		t.Error("RenderRobotsTxt() with a custom template was not successful: " + err.Error())
+	}
+}
+
 // TestRenderRobotsTxtBadRefresh tests that an error is returned when an error is encountered refreshing bot sources when rending the robots.txt template
 func TestRenderRobotsTxtBadRefresh(t *testing.T) {
 	log := logger.NewFromWriter("DEBUG", &testLogOut)


### PR DESCRIPTION
When a custom template file path is provided, the plugin fails to initialize.

This PR fixes that by naming the template `robots.txt`, which allows loading files with that basename. Documentation updated and added a unit test to capture this use case.

Closes #53 